### PR TITLE
Enabling an option to smooth the transactions with moving average.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - Layout improvements (e.g., checkbox positioning, minimized category list view).
 
 ## [Unreleased]
-### Added
 - `Main AutoBudget File (mocked).xlsx` committed once to the repo for public reference.
 - `CHANGELOG.md` and `devlog.md` files initialized for structured development tracking.
+
+### Added
+- Smoothing feature with causal moving average on all plotted lines.
+  - Users can input window size M (M ≥ 1) below each graph.
+  - Graph titles update to reflect smoothing status.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 AutoBudgetViewer - An interactive interface to monitor and visualize personal household income and expenses over time.  
 
 ### Devs: [Lior Gazit](https://github.com/LiorGazit), and GPT4.1  
-*Hours spent in total on this project so far: `2.5 hours`  
+*Hours spent in total on this project so far: `3 hours`  
 
 ## (This README is to be addressed later)
 

--- a/app.py
+++ b/app.py
@@ -66,16 +66,23 @@ for tab_name, tab_obj in zip(tabs, tab_objs):
             st.session_state[state_key] = selected
 
         with col_right:
-            # Visualization
-            plot_time_series(df, sorted(list(st.session_state[state_key])),
-                            title=f"{tab_name} – Time Series")
+            # --- Visualization controls ---
+            ma_key = f"moving_avg_{tab_name}"
+            default_ma = 1
+            M = st.number_input(
+                "Moving average window (M months):",
+                min_value=1, max_value=len(df.columns), value=default_ma, step=1,
+                key=ma_key, help="Use M=1 for no smoothing; higher for more smoothing."
+            )
 
+            plot_time_series(
+                df, 
+                sorted(list(st.session_state[state_key])),
+                title=f"{tab_name} – Time Series",
+                moving_avg=M
+            )
             # Minimal, collapsed "Selected categories" below the chart
             with st.expander("Show selected categories", expanded=False):
-                st.caption(
-                    "For validation only: currently selected categories in this tab:"
-                )
-                st.write(
-                    ", ".join(sorted(list(st.session_state[state_key]))) or "(none selected)"
-                )
+                st.caption("For validation only: currently selected categories in this tab:")
+                st.write(", ".join(sorted(list(st.session_state[state_key]))) or "(none selected)")
 

--- a/autobudget/viz.py
+++ b/autobudget/viz.py
@@ -2,9 +2,17 @@ import pandas as pd
 import streamlit as st
 import plotly.graph_objects as go
 
-def plot_time_series(df, categories, title="Category Trends Over Time"):
+def causal_moving_average(series: pd.Series, window: int) -> pd.Series:
     """
-    Plots a line chart of selected categories over time, plus their sum.
+    Computes causal moving average for a pandas Series.
+    For index t, average of values from t-(window-1) to t.
+    """
+    return series.rolling(window=window, min_periods=1).mean()
+
+
+def plot_time_series(df, categories, title="Category Trends Over Time", moving_avg=1):
+    """
+    Plots line chart of selected categories over time, plus their sum, with optional causal moving average.
     """
     if not categories:
         st.info("Select categories to view their trends.")
@@ -18,28 +26,39 @@ def plot_time_series(df, categories, title="Category Trends Over Time"):
 
     fig = go.Figure()
 
-    # Individual category lines
+    # Individual smoothed category lines
     for cat in categories:
+        y = chart_data[cat]
+        if moving_avg > 1:
+            y = causal_moving_average(y, moving_avg)
         fig.add_trace(go.Scatter(
             x=months,
-            y=chart_data[cat],
+            y=y,
             mode="lines",
             name=cat,
             line=dict(width=2)
         ))
 
-    # Add the sum line
+    # Smoothed sum line
     sum_series = chart_data.sum(axis=1)
+    if moving_avg > 1:
+        sum_series = causal_moving_average(sum_series, moving_avg)
     fig.add_trace(go.Scatter(
         x=months,
         y=sum_series,
         mode="lines",
         name="Sum of Categories",
-        line=dict(width=5, color="#d62728")  # Thick, standout color
+        line=dict(width=5, color="#d62728")
     ))
+    
+    # Dynamic title with moving average info
+    if moving_avg == 1:
+        ma_info = "(no moving average)"
+    else:
+        ma_info = f"(moving average M={moving_avg})"
 
     fig.update_layout(
-        title=title,
+        title=f"{title} {ma_info}",
         xaxis_title="Month",
         yaxis_title="Value",
         legend_title="Category",
@@ -48,3 +67,4 @@ def plot_time_series(df, categories, title="Category Trends Over Time"):
 
     st.plotly_chart(fig, use_container_width=True)
     st.caption("Each line is a category; 'Sum of Categories' is the bold curve.")
+    

--- a/devlog.md
+++ b/devlog.md
@@ -1,5 +1,15 @@
 # Development Log
 
+## 2025-07-20
+- Implemented smoothing feature using a causal moving average.
+  - Users enter integer M (M ≥ 1) to control window size.
+  - When M = 1, original data is shown without smoothing.
+  - For M > 1, graphs apply a causal average: mean of values from t-(M-1) to t.
+  - All curves, including "Sum of Categories", are smoothed accordingly.
+  - Graph titles dynamically reflect the current M setting.
+- Creating branch `staging` for accommodating for the differences between the remote `main` and my local `main`.  
+
+
 ## 2025-06-08
 - Committed the Excel file used for prototyping (`Main AutoBudget File (mocked).xlsx`) to the repo despite `.gitignore`, for transparency and reproducibility.
 - Created and committed `CHANGELOG.md` and `devlog.md` to track development milestones and ongoing work.


### PR DESCRIPTION
## 📌 Pull Request Summary
From `devlog.md`:
# Development Log

## 2025-07-20
- Implemented smoothing feature using a causal moving average.
  - Users enter integer M (M ≥ 1) to control window size.
  - When M = 1, original data is shown without smoothing.
  - For M > 1, graphs apply a causal average: mean of values from t-(M-1) to t.
  - All curves, including "Sum of Categories", are smoothed accordingly.
  - Graph titles dynamically reflect the current M setting.
- Creating branch `staging` for accommodating for the differences between the remote `main` and my local `main`. 

Validation:


## ✅ Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`README`, `devlog`, `CHANGELOG`)
- [x] My changes generate no new warnings or errors
- [x] ~I have added tests that prove my fix or feature works~
- [x] I have validated via user testing:
    1. User sees a field labeled "Moving average window (M months):" under the graph in each tab.
    2. Default is M=1 (no smoothing); user can increase for more smoothing.
    3. Graph title updates accordingly.
    4. All curves, including sum, reflect the chosen moving average.
    5. No errors for edge cases (e.g., M>number of months is capped).
- [x] All new and existing tests/validations pass
- [x] ~I have linked relevant issues (if any)~


